### PR TITLE
Small Fixes

### DIFF
--- a/reggiedata/bga.txt
+++ b/reggiedata/bga.txt
@@ -35,7 +35,7 @@
 3E02=Tuscan Columns
 3F02=Ghost Forest
 4002=Fiery Doric Colonnade
-4102=Message Box
+4102=Iggy Boss Battle Line Guides
 4202=Spiked Marble Columns
 4302=Forested Hills
 4402=None

--- a/reggiedata/tilesetinfo.xml
+++ b/reggiedata/tilesetinfo.xml
@@ -40,6 +40,15 @@
         <random range="0x28, 0x2A" />
         <random range="0x3A, 0x3D" />
     </group>
+    <group names="Pa1_korichika">
+        <random name="regular-terrain" />
+        <random range="0x6A, 0x6F" direction="horizontal" />
+        <random range="0x7A, 0x7F" />
+        <random range="0x8A, 0x8F" direction="horizontal" />
+        <random range="0x9A, 0x9F" direction="horizontal" />
+        <random range="0xAA, 0xAF" />
+        <random range="0xBA, 0xBF" direction="horizontal" />
+    </group>
     <group names="Pa1_obake_soto">
         <random range="10, 15" direction="horizontal" />
         <random range="0x1A, 0x1F" />


### PR DESCRIPTION
- Added randomisation to the Pa1_korichika tileset in NSMBW's tilesetinfo.xml
-Renamed the BgA 4102 so the name better describes what it's actually supposed to represent