### PR TITLE
Updated Levelnames.xml when Newer is selected

### DIFF
--- a/reggiedata/patches/NewerSMBW/levelnames.xml
+++ b/reggiedata/patches/NewerSMBW/levelnames.xml
@@ -278,5 +278,175 @@
 		<level file="08-41" name="Ending Cutscene" />
 		<level file="07-41" name="Credits" />
 	</category>
+	
+	<category name="New Super Mario Bros. Wii (Reference)">
+		<category name="World 1">
+			<level file="01-41NSMBW" name="Peach's Castle" />
+			<level file="01-01NSMBW" name="World 1-1" />
+			<level file="01-02NSMBW" name="World 1-2" />
+			<level file="01-03NSMBW" name="World 1-3" />
+			<level file="01-22NSMBW" name="Tower" />
+			<level file="01-04NSMBW" name="World 1-4" />
+			<level file="01-05NSMBW" name="World 1-5" />
+			<level file="01-06NSMBW" name="World 1-6" />
+			<level file="01-24NSMBW" name="Castle" />
+			<level file="01-26NSMBW" name="Toad House 1" />
+			<level file="01-27NSMBW" name="Toad House 2" />
+			<level file="01-28NSMBW" name="Toad House 3" />
+			<level file="01-29NSMBW" name="Toad House 4" />
+			<level file="01-33NSMBW" name="Goomba Ambush 1" />
+			<level file="01-34NSMBW" name="Goomba Ambush 2" />
+			<level file="01-35NSMBW" name="Goomba Ambush 3" />
+			<level file="01-36NSMBW" name="Warp Cannon" />
+			<level file="01-40NSMBW" name="Title Screen" />
+			<level file="01-42NSMBW" name="Staff Roll" />
+		</category>
+		<category name="World 2">
+			<level file="02-01NSMBW" name="World 2-1" />
+			<level file="02-02NSMBW" name="World 2-2" />
+			<level file="02-03NSMBW" name="World 2-3" />
+			<level file="02-22NSMBW" name="Tower" />
+			<level file="02-04NSMBW" name="World 2-4" />
+			<level file="02-05NSMBW" name="World 2-5" />
+			<level file="02-06NSMBW" name="World 2-6" />
+			<level file="02-24NSMBW" name="Castle" />
+			<level file="02-26NSMBW" name="Toad House 1" />
+			<level file="02-27NSMBW" name="Toad House 2" />
+			<level file="02-28NSMBW" name="Toad House 3" />
+			<level file="02-33NSMBW" name="Sand Trap 1" />
+			<level file="02-34NSMBW" name="Sand Trap 2" />
+			<level file="02-35NSMBW" name="Sand Trap 3" />
+			<level file="02-36NSMBW" name="Warp Cannon" />
+		</category>
+		<category name="World 3">
+			<level file="03-01NSMBW" name="World 3-1" />
+			<level file="03-02NSMBW" name="World 3-2" />
+			<level file="03-03NSMBW" name="World 3-3" />
+			<level file="03-21NSMBW" name="Ghost House" />
+			<level file="03-22NSMBW" name="Tower" />
+			<level file="03-04NSMBW" name="World 3-4" />
+			<level file="03-05NSMBW" name="World 3-5" />
+			<level file="03-24NSMBW" name="Castle" />
+			<level file="03-26NSMBW" name="Toad House 1" />
+			<level file="03-27NSMBW" name="Toad House 2" />
+			<level file="03-28NSMBW" name="Toad House 3" />
+			<level file="03-29NSMBW" name="Toad House 4=" />
+			<level file="03-33NSMBW" name="Ice Bros Ambush 1" />
+			<level file="03-34NSMBW" name="Ice Bros Ambush 2" />
+			<level file="03-35NSMBW" name="Ice Bros Ambush 3" />
+			<level file="03-36NSMBW" name="Warp Cannon=" />
+		</category>
+		<category name="World 4">
+			<level file="04-01NSMBW" name="World 4-1" />
+			<level file="04-02NSMBW" name="World 4-2" />
+			<level file="04-03NSMBW" name="World 4-3" />
+			<level file="04-22NSMBW" name="Tower" />
+			<level file="04-05NSMBW" name="World 4-4" />
+			<level file="04-21NSMBW" name="Ghost House" />
+			<level file="04-05NSMBW" name="World 4-5" />
+			<level file="04-24NSMBW" name="Castle" />
+			<level file="04-38NSMBW" name="Doomship" />
+			<level file="04-26NSMBW" name="Toad House 1" />
+			<level file="04-27NSMBW" name="Toad House 2" />
+			<level file="04-28NSMBW" name="Toad House 3" />
+			<level file="04-29NSMBW" name="Toad House 4" />
+			<level file="04-33NSMBW" name="Cheep Cheep Ambush 1" />
+			<level file="04-34NSMBW" name="Cheep Cheep Ambush 2" />
+			<level file="04-35NSMBW" name="Cheep Cheep Ambush 3" />
+			<level file="04-36NSMBW" name="Warp Cannon" />
+		</category>
+		<category name="World 5">
+			<level file="05-01NSMBW" name="World 5-1" />
+			<level file="05-02NSMBW" name="World 5-2" />
+			<level file="05-03NSMBW" name="World 5-3" />
+			<level file="05-22NSMBW" name="Tower" />
+			<level file="05-04NSMBW" name="World 5-4" />
+			<level file="05-21NSMBW" name="Ghost House" />
+			<level file="05-05NSMBW" name="World 5-5" />
+			<level file="05-24NSMBW" name="Castle" />
+			<level file="05-26NSMBW" name="Toad House 1" />
+			<level file="05-27NSMBW" name="Toad House 2" />
+			<level file="05-28NSMBW" name="Toad House 3" />
+			<level file="05-29NSMBW" name="Toad House 4" />
+			<level file="05-33NSMBW" name="Piranha Ambush 1" />
+			<level file="05-34NSMBW" name="Piranha Ambush 2" />
+			<level file="05-35NSMBW" name="Piranha Ambush 3" />
+			<level file="05-36NSMBW" name="Warp Cannon=" />
+		</category>
+		<category name="World 6">
+			<level file="06-01NSMBW" name="World 6-1" />
+			<level file="06-02NSMBW" name="World 6-2" />
+			<level file="06-03NSMBW" name="World 6-3" />
+			<level file="06-04NSMBW" name="World 6-4" />
+			<level file="06-22NSMBW" name="Tower" />
+			<level file="06-05NSMBW" name="World 6-5" />
+			<level file="06-06NSMBW" name="World 6-6" />
+			<level file="06-24NSMBW" name="Castle" />
+			<level file="06-38NSMBW" name="Doomship" />
+			<level file="06-26NSMBW" name="Toad House 1" />
+			<level file="06-27NSMBW" name="Toad House 2" />
+			<level file="06-28NSMBW" name="Toad House 3" />
+			<level file="06-33NSMBW" name="Bullet Ambush 1" />
+			<level file="06-34NSMBW" name="Bullet Ambush 2" />
+			<level file="06-35NSMBW" name="Bullet Ambush 3" />
+			<level file="06-36NSMBW" name="Warp Cannon" />
+		</category>
+		<category name="World 7">
+			<level file="07-01NSMBW" name="World 7-1" />
+			<level file="07-02NSMBW" name="World 7-2" />
+			<level file="07-03NSMBW" name="World 7-3" />
+			<level file="07-22NSMBW" name="Tower" />
+			<level file="07-21NSMBW" name="Ghost House" />
+			<level file="07-04NSMBW" name="World 7-4" />
+			<level file="07-05NSMBW" name="World 7-5" />
+			<level file="07-06NSMBW" name="World 7-6" />
+			<level file="07-24NSMBW" name="Castle" />
+			<level file="07-26NSMBW" name="Toad House 1" />
+			<level file="07-27NSMBW" name="Toad House 2" />
+			<level file="07-28NSMBW" name="Toad House 3" />
+			<level file="07-29NSMBW" name="Toad House 4" />
+			<level file="07-33NSMBW" name="Lakitu Ambush 1" />
+			<level file="07-34NSMBW" name="Lakitu Ambush 2" />
+			<level file="07-35NSMBW" name="Lakitu Ambush 3" />
+		</category>
+		<category name="World 8">
+			<level file="08-01NSMBW" name="World 8-1" />
+			<level file="08-02NSMBW" name="World 8-2" />
+			<level file="08-03NSMBW" name="World 8-3" />
+			<level file="08-22NSMBW" name="Tower" />
+			<level file="08-04NSMBW" name="World 8-4" />
+			<level file="08-05NSMBW" name="World 8-5" />
+			<level file="08-06NSMBW" name="World 8-6" />
+			<level file="08-07NSMBW" name="World 8-7" />
+			<level file="08-38NSMBW" name="Doomship" />
+			<level file="08-24NSMBW" name="Castle" />
+			<level file="08-26NSMBW" name="Toad House 1" />
+			<level file="08-27NSMBW" name="Toad House 2" />
+			<level file="08-28NSMBW" name="Toad House 3" />
+			<level file="08-33NSMBW" name="Podoboo Ambush 1" />
+			<level file="08-34NSMBW" name="Podoboo Ambush 2" />
+			<level file="08-35NSMBW" name="Podoboo Ambush 3" />
+		</category>
+		<category name="World 9">
+			<level file="09-01NSMBW" name="World 9-1" />
+			<level file="09-02NSMBW" name="World 9-2" />
+			<level file="09-03NSMBW" name="World 9-3" />
+			<level file="09-04NSMBW" name="World 9-4" />
+			<level file="09-05NSMBW" name="World 9-5" />
+			<level file="09-06NSMBW" name="World 9-6" />
+			<level file="09-07NSMBW" name="World 9-7" />
+			<level file="09-08NSMBW" name="World 9-8" />
+			<level file="09-26NSMBW" name="Toad House 1" />
+			<level file="09-27NSMBW" name="Toad House 2" />
+			<level file="09-28NSMBW" name="Toad House 3" />
+		</category>
+		<category name="Coin Battle Courses">
+			<level file="01-20NSMBW" name="Coin Battle 1" />
+			<level file="02-20NSMBW" name="Coin Battle 2" />
+			<level file="03-20NSMBW" name="Coin Battle 3" />
+			<level file="04-20NSMBW" name="Coin Battle 4" />
+			<level file="05-20NSMBW" name="Coin Battle 5" />
+		</category>
+	</category>
 
 </levels>


### PR DESCRIPTION
You no longer have to change games for easy access to NSMBW Levels. Instead, they can be accessed from Open Level By Name -> New Super Mario Bros Wii (Reference).

Download the renamed levels here, then put them in Newer's Stage folder.

Had to rename them for compatibility. If I did not, they would override some Newer Levels.

https://mega.nz/folder/HwUizTiA#-TovTsyMSpFeK1AuQQwZ3A