### PR TITLE
Compatibility with PyInstaller 5.0

### DIFF
--- a/build_reggie.py
+++ b/build_reggie.py
@@ -310,9 +310,7 @@ with open(SPECFILE, 'w', encoding='utf-8') as f:
 # run with minimal arguments this time.
 
 args = [
-    '--windowed',
     '--upx-dir=/path/to/upx',
-    '--upx-exclude=vcruntime140.dll',
     '--distpath=' + DIR,
     '--workpath=' + WORKPATH,
     SPECFILE,


### PR DESCRIPTION
PyInstaller, as of 5.0, [now gives an error](https://github.com/pyinstaller/pyinstaller/pull/6660) if provided arguments that should affect spec generation when already using a spec file (as Reggie Next's build script is). Reggie Next's build script currently invokes PyInstaller with redundant makespec arguments after the spec file has already been generated. This PR removes those arguments to fix building. There should be no functional difference, as the spec file is generated with them already.