### PR TITLE
Fix missing Sprite Image Update on Sprite ID Switch

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -1545,5 +1545,11 @@ class SpriteSwitchDialog(QtWidgets.QDialog):
             if sprite.type == fromType:
                 sprite.SetType(toType)
 
+                spriteClasses = globals_.gamedef.getImageClasses()
+                if sprite.type in spriteClasses:
+                    sprite.setImageObj(spriteClasses[sprite.type])
+                else:
+                    sprite.setImageObj(SLib.SpriteImage)
+
                 globals_.Area.InitialiseIdTypes()
                 SetDirty()


### PR DESCRIPTION
Fixes an issue where Sprite Images are not updated when Sprite IDs are changed until the area is reloaded or Reggie is restarted.